### PR TITLE
Auth bug fix

### DIFF
--- a/src/server/route/endpoints/auth.ts
+++ b/src/server/route/endpoints/auth.ts
@@ -2,9 +2,23 @@ import router from '../router';
 import { Request, Response } from "express";
 import { User } from '../../models';
 import { IError } from '../../interfaces/IError';
-import { bcrypt, authUser, jwtCreator } from '../../warehouse/middlewares';
+import { bcrypt, authUser, jwtCreator, jwtVerify } from '../../warehouse/middlewares';
 
 router.route('/auth')
+  .get(jwtVerify, async (req: Request, res: Response) => {
+    console.log(`Received ${req.method} request at terminal '/api/auth' endpoint`);
+    try {
+      console.log(`Success: Access to route is allowed`);
+      return res.status(201).json({ invalid: false });
+    } catch (err) {
+      const error: IError = {
+        status: 500,
+        message: `Unable to fulfull GET request: ${err}`
+      };
+      console.log(err);
+      return res.status(error.status).json(error);
+    }
+  })
   .post(authUser, bcrypt, jwtCreator, async (req: Request, res: Response) => {
     console.log(`Received ${req.method} request at terminal '/api/auth' endpoint`);
     try {

--- a/src/server/route/path.ts
+++ b/src/server/route/path.ts
@@ -7,7 +7,7 @@ function path(url: string): IPathRoute {
       methods: ['GET', 'PUT', 'DELETE']
     },
     '/auth': {
-      methods: ['POST', 'PUT']
+      methods: ['GET', 'POST', 'PUT']
     }
   }
   return allRoutes[url];

--- a/src/server/warehouse/middlewares/jwtVerify.ts
+++ b/src/server/warehouse/middlewares/jwtVerify.ts
@@ -8,12 +8,12 @@ export default (req: Request, res: Response, next: (param?: unknown) => void): v
   if (authorized.type === 'valid') {
     const tokenStatus = checkExpStatus(authorized.session);
     if (tokenStatus === 'active') {
-      console.log(`Success: JWT verified: [${req.headers.authorization}]`);
+      console.log(`Success: JWT is ${tokenStatus}: [${req.headers.authorization}]`);
       return next();
     } else {
       const error: IError = {
         status: 401,
-        message: `JWT is expired: [${req.headers.authorization}]`,
+        message: `JWT is ${tokenStatus}: [${req.headers.authorization}]`,
         invalid: true
       };
       console.log(`Fail: ${error.message}`);


### PR DESCRIPTION
Currently, user is allowed to access protected pages on the backend even after token is expired.

- Added GET method to auth endpoint to allow frontend to check if token is still valid. Frontend functionality should reject attempt to load page if token is expired or tampered with.